### PR TITLE
[#3] Add support for tags in filters

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,5 +1,6 @@
 import { configure } from '@kadira/storybook';
 import '../node_modules/bootstrap/dist/css/bootstrap.min.css';
+import '../node_modules/react-select/dist/react-select.min.css';
 
 function loadStories() {
   require('../stories');

--- a/README.md
+++ b/README.md
@@ -113,8 +113,16 @@ Columns definitions have the following properties:
  - _primaryKey_ defines if this column is the primary key
  - _hidden_ defines if we should hide this column (useful if you don't want to show primary key column)
  - _Component_ defines which component should be used to render cell contents
+ - _filterable_ defines if user should be able to filter rows by distinct values of this column
+ - _filterValues_ can be provided to define distinct filter values for this
+   column. If not provided, unique values will be extracted from provided data.
+ - _getFilterTitle_ is a function with `(value)` signature that can be provided to customize the filter title
+ - _getFilterLabel_ is a function with `(value)` signature that can be provided to customize the filter label
+ - _getFilterClassName_ is a function with `(value)` signature that can be provided to customize the filter css class
 
 At least one column definition should have `primaryKey: true`.
+
+Check out `stories/UsersTable.js` to see how these properties can be used.
 
 ## Advanced Usage
 
@@ -249,9 +257,42 @@ You can use the below actions to alter the state of the table:
  - `tableDestroyState(tableName)` resets/destroys the current state of the
    table. This can be used in `componentWillUnmount()` to reset the related
    redux state.
+ - `tableSetFilter(tableName, filterValue)` sets the table filters where
+   `filterValue` is an array of filter objects.
 
 You can import actions from the sematable module like this:
 
 ```javascript
 import { tableDestroyState } from 'sematable';
+```
+
+## Filters
+
+You can set the list of filters by passing `filterValue` to your sematable
+component, or by using the `tableSetFilter` action. In either case, the
+provided value should be an array of two types of objects:
+
+ - text filter defined simply as a string
+ - value filter defined as object with properties `key` and `value`, where
+   `key` is the column key you want to filter, and `value` is the value you
+   want to filter by.
+
+For example:
+
+```javascript
+<UsersTable
+  data={users}
+  filterValue={[
+    'Bob',
+    { key: 'confirmed', value: true },
+  ]}
+/>
+```
+Or with `tableSetFilter`:
+
+```javascript
+dispatch(tableSetFilter('usersTable', [
+  'Bob',
+  { key: 'confirmed', value: true },
+]));
 ```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 Sematable wraps a table component, and provides:
 
- - filtering
+ - filtering by column value
+ - search with text
  - sorting
  - row selection
  - pagination
@@ -42,8 +43,8 @@ import sematable, { Table } from 'sematable';
 import AppsTableActions from './AppsTableActions';
 
 const columns = [
-  { key: 'id', header: 'ID', sortable: true, filterable: true, primaryKey: true },
-  { key: 'name', header: 'Application', sortable: true, filterable: true },
+  { key: 'id', header: 'ID', sortable: true, searchable: true, primaryKey: true },
+  { key: 'name', header: 'Application', sortable: true, searchable: true },
   { key: 'token', header: 'Token' },
   { key: 'plan', header: 'Plan', sortable: true },
   { key: 'role', header: 'Role', sortable: true },
@@ -108,7 +109,7 @@ Columns definitions have the following properties:
  - _key_ is the name of the property used in row objects
  - _header_ is the header label that will be used for this column
  - _sortable_ defines if user should be able to sort by this column
- - _filterable_ defines if user should be able to filter by this column (simple case-insensitive substring search)
+ - _searchable_ defines if user should be able to text-search by this column (simple case-insensitive substring search)
  - _primaryKey_ defines if this column is the primary key
  - _hidden_ defines if we should hide this column (useful if you don't want to show primary key column)
  - _Component_ defines which component should be used to render cell contents
@@ -157,8 +158,8 @@ import sematable, {
 } from 'sematable';
 
 const columns = {
-  id: { header: 'ID', filterable: true, sortable: true, primaryKey: true },
-  name: { header: 'Name', filterable: true, sortable: true },
+  id: { header: 'ID', searchable: true, sortable: true, primaryKey: true },
+  name: { header: 'Name', searchable: true, sortable: true },
 };
 
 const propTypes = {

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "react": "^15.1.0",
     "react-dom": "^15.3.2",
     "react-redux": "^4.4.5",
+    "react-select": "^1.0.0-rc.1",
     "redux": "^3.4.0",
     "redux-actions": "^0.11.0",
     "reselect": "^2.5.3"

--- a/src/Filter.js
+++ b/src/Filter.js
@@ -28,7 +28,7 @@ class Filter extends Component {
     return (
       <Creatable
         options={options}
-        noResultsText="No tags found, type text and press Enter to search"
+        noResultsText="Type text to search, press Enter to save as filter"
         placeholder="Search by text or tags"
         promptTextCreator={(txt) => `Search for '${txt}'`}
         onChange={(selected) => onChange(selected)}

--- a/src/Filter.js
+++ b/src/Filter.js
@@ -10,6 +10,14 @@ const propTypes = {
 };
 
 class Filter extends Component {
+  shouldComponentUpdate(nextProps) {
+    const { value, options } = this.props;
+    if (nextProps.value !== value || nextProps.options !== options) {
+      return true;
+    }
+    return false;
+  }
+
   render() {
     const {
       value,
@@ -24,7 +32,10 @@ class Filter extends Component {
         placeholder="Search by text or tags"
         promptTextCreator={(txt) => `Search for '${txt}'`}
         onChange={(selected) => onChange(selected)}
-        onInputChange={(text) => onTextChange(text)}
+        onInputChange={(text) => {
+          onTextChange(text);
+          return text;
+        }}
         onBlurResetsInput={false}
         onCloseResetsInput={false}
         newOptionCreator={({ label }) => createTextFilter(label)}

--- a/src/Filter.js
+++ b/src/Filter.js
@@ -1,5 +1,6 @@
 import React, { Component, PropTypes } from 'react';
 import { Creatable } from 'react-select';
+import { createTextFilter } from './common';
 
 const propTypes = {
   value: PropTypes.array,
@@ -21,14 +22,7 @@ class Filter extends Component {
         placeholder="Search by text or tags"
         promptTextCreator={(txt) => `Search for '${txt}'`}
         onChange={(selected) => onChange(selected)}
-        newOptionCreator={({ label, labelKey, valueKey }) => {
-          const option = {};
-          option[valueKey] = label.toLowerCase();
-          option[labelKey] = label.toLowerCase();
-          option.textFilter = true;
-          option.className = 'Select-create-option-placeholder';
-          return option;
-        }}
+        newOptionCreator={({ label }) => createTextFilter(label)}
         value={value}
         multi
         style={{

--- a/src/Filter.js
+++ b/src/Filter.js
@@ -5,6 +5,7 @@ import { createTextFilter } from './common';
 const propTypes = {
   value: PropTypes.array,
   onChange: PropTypes.func.isRequired,
+  onTextChange: PropTypes.func.isRequired,
   options: PropTypes.array.isRequired,
 };
 
@@ -13,6 +14,7 @@ class Filter extends Component {
     const {
       value,
       onChange,
+      onTextChange,
       options,
     } = this.props;
     return (
@@ -22,6 +24,9 @@ class Filter extends Component {
         placeholder="Search by text or tags"
         promptTextCreator={(txt) => `Search for '${txt}'`}
         onChange={(selected) => onChange(selected)}
+        onInputChange={(text) => onTextChange(text)}
+        onBlurResetsInput={false}
+        onCloseResetsInput={false}
         newOptionCreator={({ label }) => createTextFilter(label)}
         value={value}
         multi

--- a/src/Filter.js
+++ b/src/Filter.js
@@ -1,8 +1,10 @@
 import React, { Component, PropTypes } from 'react';
+import { Creatable } from 'react-select';
 
 const propTypes = {
-  value: PropTypes.string,
+  value: PropTypes.array,
   onChange: PropTypes.func.isRequired,
+  options: PropTypes.array.isRequired,
 };
 
 class Filter extends Component {
@@ -10,13 +12,25 @@ class Filter extends Component {
     const {
       value,
       onChange,
+      options,
     } = this.props;
     return (
-      <input
-        className="form-control"
-        onChange={(e) => onChange(e.target.value)}
+      <Creatable
+        options={options}
+        noResultsText="No tags found, type text and press Enter to search"
+        placeholder="Search by text or tags"
+        promptTextCreator={(txt) => `Search for '${txt}'`}
+        onChange={(selected) => onChange(selected)}
+        newOptionCreator={({ label, labelKey, valueKey }) => {
+          const option = {};
+          option[valueKey] = label.toLowerCase();
+          option[labelKey] = label.toLowerCase();
+          option.textFilter = true;
+          option.className = 'Select-create-option-placeholder';
+          return option;
+        }}
         value={value}
-        placeholder="Filter data with any text"
+        multi
         style={{
           margin: '1rem 0 1rem 0',
         }}

--- a/src/actions.js
+++ b/src/actions.js
@@ -7,6 +7,7 @@ export const TABLE_SORT_CHANGED = 'sematable/TABLE_SORT_CHANGED';
 export const TABLE_ROW_CHECKED_CHANGED = 'sematable/TABLE_ROW_CHECKED_CHANGED';
 export const TABLE_SELECT_ALL_CHANGED = 'sematable/TABLE_SELECT_ALL_CHANGED';
 export const TABLE_DESTROY_STATE = 'sematable/TABLE_DESTROY_STATE';
+export const TABLE_SET_FILTER = 'sematable/TABLE_SET_FILTER';
 
 export const tableInitialize = (tableName, initialData, columns, configs) => ({
   type: TABLE_INITIALIZE,
@@ -77,5 +78,13 @@ export const tableDestroyState = (tableName) => ({
   type: TABLE_DESTROY_STATE,
   payload: {
     tableName,
+  },
+});
+
+export const tableSetFilter = (tableName, filterValue) => ({
+  type: TABLE_SET_FILTER,
+  payload: {
+    tableName,
+    filterValue,
   },
 });

--- a/src/actions.js
+++ b/src/actions.js
@@ -3,6 +3,7 @@ export const TABLE_NEW_DATA = 'sematable/TABLE_NEW_DATA';
 export const TABLE_PAGE_CHANGED = 'sematable/TABLE_PAGE_CHANGED';
 export const TABLE_PAGE_SIZE_CHANGED = 'sematable/TABLE_PAGE_SIZE_CHANGED';
 export const TABLE_FILTER_CHANGED = 'sematable/TABLE_FILTER_CHANGED';
+export const TABLE_FILTER_TEXT_CHANGED = 'sematable/TABLE_FILTER_TEXT_CHANGED';
 export const TABLE_SORT_CHANGED = 'sematable/TABLE_SORT_CHANGED';
 export const TABLE_ROW_CHECKED_CHANGED = 'sematable/TABLE_ROW_CHECKED_CHANGED';
 export const TABLE_SELECT_ALL_CHANGED = 'sematable/TABLE_SELECT_ALL_CHANGED';
@@ -48,6 +49,14 @@ export const tableFilterChanged = (tableName, filter) => ({
   payload: {
     tableName,
     filter,
+  },
+});
+
+export const tableFilterTextChanged = (tableName, filterText) => ({
+  type: TABLE_FILTER_TEXT_CHANGED,
+  payload: {
+    tableName,
+    filterText,
   },
 });
 

--- a/src/common.js
+++ b/src/common.js
@@ -10,9 +10,9 @@ export const createTextFilter = (text) => ({
 export const createValueFilter = (column, value) => {
   const {
     key,
-    getValueTitle = () => undefined,
-    getValueClassName = () => undefined,
-    getValueLabel = () => {
+    getFilterTitle = () => undefined,
+    getFilterClassName = () => undefined,
+    getFilterLabel = () => {
       let labelValue = value;
       if (_.isBoolean(value)) {
         labelValue = value ? 'Yes' : 'No';
@@ -20,9 +20,9 @@ export const createValueFilter = (column, value) => {
       return `${column.header}:${labelValue}`;
     },
   } = column;
-  const title = getValueTitle(value);
-  const label = getValueLabel(value);
-  const className = getValueClassName(value);
+  const title = getFilterTitle(value);
+  const label = getFilterLabel(value);
+  const className = getFilterClassName(value);
   return {
     key,
     label,

--- a/src/common.js
+++ b/src/common.js
@@ -1,0 +1,34 @@
+import _ from 'lodash';
+
+export const createTextFilter = (text) => ({
+  value: text.toLowerCase(),
+  label: text.toLowerCase(),
+  textFilter: true,
+  className: 'Select-create-option-placeholder',
+});
+
+export const createValueFilter = (column, value) => {
+  const {
+    key,
+    getValueTitle = () => undefined,
+    getValueClassName = () => undefined,
+    getValueLabel = () => {
+      let labelValue = value;
+      if (_.isBoolean(value)) {
+        labelValue = value ? 'Yes' : 'No';
+      }
+      return `${column.header}:${labelValue}`;
+    },
+  } = column;
+  const title = getValueTitle(value);
+  const label = getValueLabel(value);
+  const className = getValueClassName(value);
+  return {
+    key,
+    label,
+    value,
+    title,
+    className,
+    valueFilter: true,
+  };
+};

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ import TableRow from './TableRow.js';
 import Table from './Table.js';
 import makeSelectors from './selectors.js';
 import reducer from './reducer.js';
-import { tableDestroyState } from './actions.js';
+import { tableDestroyState, tableSetFilter } from './actions.js';
 
 export {
   SortableHeader,
@@ -16,6 +16,7 @@ export {
   TableRow,
   makeSelectors,
   tableDestroyState,
+  tableSetFilter,
   reducer,
 };
 export default sematable;

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -7,6 +7,7 @@ import {
   TABLE_PAGE_SIZE_CHANGED,
   TABLE_SORT_CHANGED,
   TABLE_FILTER_CHANGED,
+  TABLE_FILTER_TEXT_CHANGED,
   TABLE_SELECT_ALL_CHANGED,
   TABLE_ROW_CHECKED_CHANGED,
   TABLE_DESTROY_STATE,
@@ -89,6 +90,11 @@ const behaviours = {
     ...state,
     page: 0,
     filter: payload.filter,
+  }),
+  [TABLE_FILTER_TEXT_CHANGED]: (state, { payload }) => ({
+    ...state,
+    page: 0,
+    filterText: payload.filterText,
   }),
   [TABLE_SELECT_ALL_CHANGED]: (state) => ({
     ...state,

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -15,7 +15,7 @@ import {
 const defaultState = (configs = {}) => ({
   page: 0,
   pageSize: configs.defaultPageSize || 5,
-  filter: '',
+  filter: [],
   sortKey: null,
   direction: null,
   selectAll: false,
@@ -72,7 +72,7 @@ const behaviours = {
   [TABLE_FILTER_CHANGED]: (state, { payload }) => ({
     ...state,
     page: 0,
-    filter: payload.filter.toLowerCase(),
+    filter: payload.filter,
   }),
   [TABLE_SELECT_ALL_CHANGED]: (state) => ({
     ...state,

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -104,7 +104,10 @@ const behaviours = {
       ],
     };
   },
-  [TABLE_DESTROY_STATE]: (state) => defaultState(state.configs),
+  [TABLE_DESTROY_STATE]: (state) => ({
+    ...state,
+    ...defaultState(state.configs),
+  }),
 };
 
 const tableReducer = handleActions(behaviours);

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -10,7 +10,9 @@ import {
   TABLE_SELECT_ALL_CHANGED,
   TABLE_ROW_CHECKED_CHANGED,
   TABLE_DESTROY_STATE,
+  TABLE_SET_FILTER,
 } from './actions.js';
+import { createTextFilter, createValueFilter } from './common';
 
 const defaultState = (configs = {}) => ({
   page: 0,
@@ -46,6 +48,20 @@ const behaviours = {
     ...state,
     initialData: payload.data,
   }),
+  [TABLE_SET_FILTER]: (state, { payload }) => {
+    const columnMap = _.keyBy(state.columns, 'key');
+    const filter = payload.filterValue.map(f => {
+      if (_.isString(f)) {
+        return createTextFilter(f);
+      }
+      const column = columnMap[f.key];
+      return createValueFilter(column, f.value);
+    });
+    return {
+      ...state,
+      filter,
+    };
+  },
   [TABLE_PAGE_CHANGED]: (state, { payload }) => ({
     ...state,
     page: payload.page,

--- a/src/selectors.js
+++ b/src/selectors.js
@@ -89,12 +89,20 @@ export default (tableName) => {
     getColumns,
     (initialData, columns) => {
       const options = [];
-      const values = {};
       const columnMap = _.keyBy(columns, 'key');
+      const values = {};
 
+      // set predefined values
+      columns.forEach(column => {
+        if (column.taggable && column.values) {
+          values[column.key] = column.values;
+        }
+      });
+
+      // collect values for columns that don't have predefined values
       initialData.forEach(row => {
         columns.forEach(column => {
-          if (!column.taggable) {
+          if (!column.taggable || column.values) {
             return;
           }
           if (!values[column.key]) {

--- a/src/selectors.js
+++ b/src/selectors.js
@@ -1,5 +1,6 @@
-import { createSelector } from 'reselect';
 import _ from 'lodash';
+import { createSelector } from 'reselect';
+import { createValueFilter } from './common';
 
 function paginate(rows, { page, pageSize }) {
   if (pageSize < 1) {
@@ -119,28 +120,7 @@ export default (tableName) => {
       _.forOwn(values, (columnValues, key) => {
         columnValues.forEach(value => {
           const column = columnMap[key];
-          const {
-            getValueTitle = () => undefined,
-            getValueClassName = () => undefined,
-            getValueLabel = () => {
-              let labelValue = value;
-              if (_.isBoolean(value)) {
-                labelValue = value ? 'Yes' : 'No';
-              }
-              return `${column.header}:${labelValue}`;
-            },
-          } = column;
-          const title = getValueTitle(value);
-          const label = getValueLabel(value);
-          const className = getValueClassName(value);
-          options.push({
-            key,
-            label,
-            value,
-            title,
-            className,
-            valueFilter: true,
-          });
+          options.push(createValueFilter(column, value));
         });
       });
 

--- a/src/selectors.js
+++ b/src/selectors.js
@@ -32,7 +32,7 @@ function filter(rows = [], filters = [], filterText, columns) {
   if (textFilters.length > 0) {
     // apply text filters across all columns
     filteredRows = _.filter(rows, row => _.some(columns, (column) => {
-      if (!column.filterable) {
+      if (!column.searchable) {
         return false;
       }
       const normalized = String(_.get(row, column.key)).toLowerCase();

--- a/src/selectors.js
+++ b/src/selectors.js
@@ -41,9 +41,9 @@ function filter(rows = [], filters = [], filterText, columns) {
   }
 
   if (valueFilters.length > 0) {
-    // apply value filters on taggable columns
+    // apply value filters on filterable columns
     filteredRows = _.filter(filteredRows, row => _.every(columns, column => {
-      if (!column.taggable) {
+      if (!column.filterable) {
         return true;
       }
       const value = _.get(row, column.key);
@@ -117,15 +117,15 @@ export default (tableName) => {
 
       // set predefined values
       columns.forEach(column => {
-        if (column.taggable && column.values) {
-          values[column.key] = column.values;
+        if (column.filterable && column.filterValues) {
+          values[column.key] = column.filterValues;
         }
       });
 
       // collect values for columns that don't have predefined values
       initialData.forEach(row => {
         columns.forEach(column => {
-          if (!column.taggable || column.values) {
+          if (!column.filterable || column.filterValues) {
             return;
           }
           if (!values[column.key]) {

--- a/src/selectors.js
+++ b/src/selectors.js
@@ -110,15 +110,28 @@ export default (tableName) => {
 
       _.forOwn(values, (columnValues, key) => {
         columnValues.forEach(value => {
-          let labelValue = value;
-          if (_.isBoolean(value)) {
-            labelValue = value ? 'Yes' : 'No';
-          }
+          const column = columnMap[key];
+          const {
+            getValueTitle = () => undefined,
+            getValueClassName = () => undefined,
+            getValueLabel = () => {
+              let labelValue = value;
+              if (_.isBoolean(value)) {
+                labelValue = value ? 'Yes' : 'No';
+              }
+              return `${column.header}:${labelValue}`;
+            },
+          } = column;
+          const title = getValueTitle(value);
+          const label = getValueLabel(value);
+          const className = getValueClassName(value);
           options.push({
-            label: `${columnMap[key].header}:${labelValue}`,
-            valueFilter: true,
-            value,
             key,
+            label,
+            value,
+            title,
+            className,
+            valueFilter: true,
           });
         });
       });

--- a/src/sematable.js
+++ b/src/sematable.js
@@ -53,8 +53,8 @@ const propTypes = {
  * and column definitions.  Column definitions should look like this:
  *
  *  {
- *    id: { header: 'ID', filterable: true },
- *    name: { header: 'Name', filterable: true },
+ *    id: { header: 'ID', searchable: true },
+ *    name: { header: 'Name', searchable: true },
  *  };
  *
  */

--- a/src/sematable.js
+++ b/src/sematable.js
@@ -14,6 +14,7 @@ import {
   tableSortChanged,
   tableRowCheckedChanged,
   tableSelectAllChanged,
+  tableSetFilter,
 } from './actions.js';
 
 const propTypes = {
@@ -28,6 +29,7 @@ const propTypes = {
   selectedRows: PropTypes.array,
   primaryKey: PropTypes.string,
   filterOptions: PropTypes.array,
+  filterValue: PropTypes.array,
 
   onPageChange: PropTypes.func.isRequired,
   onPageSizeChange: PropTypes.func.isRequired,
@@ -35,6 +37,7 @@ const propTypes = {
   onHeaderClick: PropTypes.func.isRequired,
   onInitialize: PropTypes.func.isRequired,
   onNewData: PropTypes.func.isRequired,
+  onNewFilterValue: PropTypes.func.isRequired,
   onRowCheckedChange: PropTypes.func.isRequired,
   onSelectAllChange: PropTypes.func.isRequired,
 };
@@ -82,6 +85,7 @@ const sematable = (tableName, TableComponent, columns, configs = {}) => {
     onFilterChange: (filter) => dispatch(tableFilterChanged(tableName, filter)),
     onHeaderClick: (sortKey) => dispatch(tableSortChanged(tableName, sortKey)),
     onNewData: (data) => dispatch(tableNewData(tableName, data)),
+    onNewFilterValue: (data) => dispatch(tableSetFilter(tableName, data)),
     onSelectAllChange: () => dispatch(tableSelectAllChanged(tableName)),
     onRowCheckedChange: (row) => dispatch(tableRowCheckedChanged(tableName, row)),
     onInitialize: (data) => dispatch(tableInitialize(tableName, data, columns, configs)),
@@ -94,9 +98,20 @@ const sematable = (tableName, TableComponent, columns, configs = {}) => {
     }
 
     componentWillReceiveProps(nextProps) {
-      const { data, onNewData } = this.props;
+      const {
+        data,
+        filterValue,
+        onNewData,
+        onNewFilterValue,
+      } = this.props;
+
       if (data !== nextProps.data) {
         onNewData(nextProps.data);
+      }
+
+      if (filterValue !== nextProps.filterValue) {
+        console.log(filterValue);
+        onNewFilterValue(filterValue);
       }
     }
 

--- a/src/sematable.js
+++ b/src/sematable.js
@@ -110,7 +110,6 @@ const sematable = (tableName, TableComponent, columns, configs = {}) => {
       }
 
       if (filterValue !== nextProps.filterValue) {
-        console.log(filterValue);
         onNewFilterValue(filterValue);
       }
     }

--- a/src/sematable.js
+++ b/src/sematable.js
@@ -11,6 +11,7 @@ import {
   tablePageChanged,
   tablePageSizeChanged,
   tableFilterChanged,
+  tableFilterTextChanged,
   tableSortChanged,
   tableRowCheckedChanged,
   tableSelectAllChanged,
@@ -34,6 +35,7 @@ const propTypes = {
   onPageChange: PropTypes.func.isRequired,
   onPageSizeChange: PropTypes.func.isRequired,
   onFilterChange: PropTypes.func.isRequired,
+  onFilterTextChange: PropTypes.func.isRequired,
   onHeaderClick: PropTypes.func.isRequired,
   onInitialize: PropTypes.func.isRequired,
   onNewData: PropTypes.func.isRequired,
@@ -83,6 +85,7 @@ const sematable = (tableName, TableComponent, columns, configs = {}) => {
     onPageChange: (page) => dispatch(tablePageChanged(tableName, page)),
     onPageSizeChange: (pageSize) => dispatch(tablePageSizeChanged(tableName, pageSize)),
     onFilterChange: (filter) => dispatch(tableFilterChanged(tableName, filter)),
+    onFilterTextChange: (filterText) => dispatch(tableFilterTextChanged(tableName, filterText)),
     onHeaderClick: (sortKey) => dispatch(tableSortChanged(tableName, sortKey)),
     onNewData: (data) => dispatch(tableNewData(tableName, data)),
     onNewFilterValue: (data) => dispatch(tableSetFilter(tableName, data)),
@@ -131,6 +134,7 @@ const sematable = (tableName, TableComponent, columns, configs = {}) => {
         onPageChange,
         onPageSizeChange,
         onFilterChange,
+        onFilterTextChange,
         onHeaderClick,
         onRowCheckedChange,
         onSelectAllChange,
@@ -183,6 +187,7 @@ const sematable = (tableName, TableComponent, columns, configs = {}) => {
               value={filter}
               options={filterOptions}
               onChange={(f) => onFilterChange(f)}
+              onTextChange={(f) => onFilterTextChange(f)}
             />}
           </div>
           <div className="col-md-12">

--- a/src/sematable.js
+++ b/src/sematable.js
@@ -21,12 +21,13 @@ const propTypes = {
 
   isInitialized: PropTypes.bool.isRequired,
   visibleRows: PropTypes.array,
-  filter: PropTypes.string,
+  filter: PropTypes.array,
   sortInfo: PropTypes.object,
   pageInfo: PropTypes.object,
   selectAll: PropTypes.bool,
   selectedRows: PropTypes.array,
   primaryKey: PropTypes.string,
+  filterOptions: PropTypes.array,
 
   onPageChange: PropTypes.func.isRequired,
   onPageSizeChange: PropTypes.func.isRequired,
@@ -71,6 +72,7 @@ const sematable = (tableName, TableComponent, columns, configs = {}) => {
       selectAll: selectors.getSelectAll(state),
       selectedRows: selectors.getSelectedRows(state),
       primaryKey: selectors.getPrimaryKey(state),
+      filterOptions: selectors.getFilterOptions(state),
     };
   };
 
@@ -109,6 +111,7 @@ const sematable = (tableName, TableComponent, columns, configs = {}) => {
         selectAll,
         selectedRows,
         primaryKey,
+        filterOptions,
 
         /* actions */
         onPageChange,
@@ -164,6 +167,7 @@ const sematable = (tableName, TableComponent, columns, configs = {}) => {
           <div className="col-md-6">
             {showFilter && <Filter
               value={filter}
+              options={filterOptions}
               onChange={(f) => onFilterChange(f)}
             />}
           </div>

--- a/stories/UsersTable.js
+++ b/stories/UsersTable.js
@@ -12,6 +12,11 @@ const columns = [
     key: 'status',
     header: 'Status',
     taggable: true,
+    values: [
+      'UNKNOWN',
+      'ACTIVE',
+      'DISABLED',
+    ],
     getValueTitle: (value) => ({
       UNKNOWN: 'Gone missing users',
       ACTIVE: 'Active users',

--- a/stories/UsersTable.js
+++ b/stories/UsersTable.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import sematable, { Table } from '../src';
+import YesNo from './YesNo.js';
 
 export const USERS_TABLE = 'usersTable';
 const columns = [
@@ -7,6 +8,7 @@ const columns = [
   { key: 'firstName', header: 'First name', filterable: true, sortable: true },
   { key: 'lastName', header: 'Last name', filterable: true, sortable: true },
   { key: 'status', header: 'Status', taggable: true },
+  { key: 'confirmed', header: 'Confirmed', taggable: true, Component: YesNo },
 ];
 
 class UsersTable extends Component {

--- a/stories/UsersTable.js
+++ b/stories/UsersTable.js
@@ -6,8 +6,8 @@ import './style.css';
 export const USERS_TABLE = 'usersTable';
 const columns = [
   { key: 'id', primaryKey: true, header: 'ID' },
-  { key: 'firstName', header: 'First name', filterable: true, sortable: true },
-  { key: 'lastName', header: 'Last name', filterable: true, sortable: true },
+  { key: 'firstName', header: 'First name', searchable: true, sortable: true },
+  { key: 'lastName', header: 'Last name', searchable: true, sortable: true },
   {
     key: 'status',
     header: 'Status',

--- a/stories/UsersTable.js
+++ b/stories/UsersTable.js
@@ -1,14 +1,30 @@
 import React, { Component } from 'react';
 import sematable, { Table } from '../src';
 import YesNo from './YesNo.js';
+import './style.css';
 
 export const USERS_TABLE = 'usersTable';
 const columns = [
   { key: 'id', primaryKey: true, header: 'ID' },
   { key: 'firstName', header: 'First name', filterable: true, sortable: true },
   { key: 'lastName', header: 'Last name', filterable: true, sortable: true },
-  { key: 'status', header: 'Status', taggable: true },
-  { key: 'confirmed', header: 'Confirmed', taggable: true, Component: YesNo },
+  {
+    key: 'status',
+    header: 'Status',
+    taggable: true,
+    getValueTitle: (value) => ({
+      UNKNOWN: 'Gone missing users',
+      ACTIVE: 'Active users',
+    }[value]),
+    getValueClassName: (value) => `col-${value.toLowerCase()}`,
+  },
+  {
+    key: 'confirmed',
+    header: 'Confirmed',
+    Component: YesNo,
+    taggable: true,
+    getValueTitle: (value) => value ? 'Confirmed' : 'Not confirmed',
+  },
 ];
 
 class UsersTable extends Component {

--- a/stories/UsersTable.js
+++ b/stories/UsersTable.js
@@ -11,24 +11,24 @@ const columns = [
   {
     key: 'status',
     header: 'Status',
-    taggable: true,
-    values: [
+    filterable: true,
+    filterValues: [
       'UNKNOWN',
       'ACTIVE',
       'DISABLED',
     ],
-    getValueTitle: (value) => ({
+    getFilterTitle: (value) => ({
       UNKNOWN: 'Gone missing users',
       ACTIVE: 'Active users',
     }[value]),
-    getValueClassName: (value) => `col-${value.toLowerCase()}`,
+    getFilterClassName: (value) => `col-${value.toLowerCase()}`,
   },
   {
     key: 'confirmed',
     header: 'Confirmed',
     Component: YesNo,
-    taggable: true,
-    getValueTitle: (value) => value ? 'Confirmed' : 'Not confirmed',
+    filterable: true,
+    getFilterTitle: (value) => value ? 'Confirmed' : 'Not confirmed',
   },
 ];
 

--- a/stories/YesNo.js
+++ b/stories/YesNo.js
@@ -1,0 +1,10 @@
+import React, { PropTypes } from 'react';
+
+const YesNo = ({ children }) => (
+  <span>{children ? 'Yes' : 'No'}</span>
+);
+
+YesNo.propTypes = {
+  children: PropTypes.bool.isRequired,
+};
+export default YesNo;

--- a/stories/index.js
+++ b/stories/index.js
@@ -14,12 +14,14 @@ const users = [
     firstName: 'John',
     lastName: 'Doe',
     status: 'UNKNOWN',
+    confirmed: true,
   },
   {
     id: 2,
     firstName: 'Bob',
     lastName: 'McBobber',
     status: 'ACTIVE',
+    confirmed: false,
   },
 ];
 

--- a/stories/index.js
+++ b/stories/index.js
@@ -37,7 +37,13 @@ storiesOf('Sematable', module)
         >
           Reset state
         </button>
-        <UsersTable data={users} />
+        <UsersTable
+          data={users}
+          filterValue={[
+            'o',
+            { key: 'confirmed', value: true },
+          ]}
+        />
       </div>
     </Provider>
   ));

--- a/stories/style.css
+++ b/stories/style.css
@@ -1,0 +1,8 @@
+.col-unknown,
+.col-unknown > span {
+  color: red;
+}
+.col-active,
+.col-active > span {
+  color: blue;
+}


### PR DESCRIPTION
Adds support for tags/valueFilterable in filters.

- [x] User must be able to filter the table by selecting predefined tags in the filter. By default, the tags must be generated from the provided data by taking unique values for each column that is marked as taggable.
- [x] The tags must be auto-completed while user is typing, and the tags should be displayed in the form of "ColumnName:TagValue".
- [x] User must still be able to use the filter for free form text search.
- [x] Developer must specify that a column is taggable by setting taggable: true in the column definition.
- [x] Developer must be able to programmatically add or remove tags from the filter.
- [x] Developer must be able to pass the list of selected filters as props.
- [x] Developer should be able to override the available tags for each column by defining tags: ['value1', 'value2'] in the column definition.
- [x] Developer should be able to provide a class name for each distinct tag value so it's possible to customize how the tag is displayed in the filter dropdown.
- [x] Developer should be able to provide custom title for each filter value
- [x] Better naming, use `searchable` and `filterable`, rename related callbacks and options
- [x] Update README with examples for filters