### PR TITLE
allow more general headers (by allowing nodes)

### DIFF
--- a/src/SortableHeader.js
+++ b/src/SortableHeader.js
@@ -2,7 +2,7 @@ import React, { Component, PropTypes } from 'react';
 
 const propTypes = {
   sortKey: PropTypes.string.isRequired,
-  name: PropTypes.string.isRequired,
+  name: PropTypes.node.isRequired,
   handleClick: PropTypes.func.isRequired,
   sorted: PropTypes.string,
 };


### PR DESCRIPTION
Allows to add elements or in general nodes as column headers. This is already possible but it throws a type warning. This pull request removes this type warning by relaxing the type check.