### PR TITLE
Remove col-md-6 inside col-md-6

### DIFF
--- a/src/PageSize.js
+++ b/src/PageSize.js
@@ -18,7 +18,7 @@ class PageSize extends Component {
       pageSizes,
       totalSize,
       onChange,
-      className = 'col-md-6',
+      className,
     } = this.props;
     return (
       <div


### PR DESCRIPTION
Because it makes column take only half of available width. Symptom:
breaks the " of <row_count>" part of PageSize into new row.