### PR TITLE
Add ability to specify class on <td>

### DIFF
--- a/src/TableRow.js
+++ b/src/TableRow.js
@@ -52,7 +52,7 @@ class TableRow extends Component {
           </td>
         }
         {visibleColumns.map((col) =>
-          <td key={col.key}>
+          <td key={col.key} className={col.className}>
             {col.Component ?
               <col.Component
                 row={row}


### PR DESCRIPTION
You can now set `<td>` `className` in column props