### PR TITLE
Add 15 and 20 to available pageSizes

### DIFF
--- a/src/reducer.js
+++ b/src/reducer.js
@@ -20,7 +20,7 @@ import { PAGE_SIZE_ALL_VALUE } from './PageSize';
 const defaultState = (configs = {}) => ({
   page: 0,
   pageSize: configs.defaultPageSize || 5,
-  pageSizes: configs.defaultPageSizes || [5, 10, 50, 100, PAGE_SIZE_ALL_VALUE],
+  pageSizes: configs.defaultPageSizes || [5, 10, 15, 20, 50, 100, PAGE_SIZE_ALL_VALUE],
   filter: [],
   filterText: null,
   sortKey: configs.sortKey,


### PR DESCRIPTION
So granular because users usually want to use all the space available and this makes this fine tuneable.
I wanted to make the default 10 instead of 5, but that would "break" backwards compatibility, so didn't do that.