### PR TITLE
Custom sort icons and pagination classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,8 @@ The `sematable(tableName, component, columns, configs)` wrapper accepts four par
  - _filterPlaceholder_ filter placeholder text
  - _pageSizeClassName_ css class for the page size component ('col-md-6' by default)
  - _pageSizeContainerClassName_ css class for the page size component container element ('col-md-6' by default)
+ - _paginationClassName_ css class for the pagination component (`null` by default)
+ - _paginationContainerClassName_ css class for the pagination component container element ('col-md-12' by default)
  - _sortKey_ default column to sort by (not sorted by default)
  - _sortDirection_ default sort direction, `asc` or `desc` (`asc` by default)
 

--- a/README.md
+++ b/README.md
@@ -173,6 +173,10 @@ The `sematable(tableName, component, columns, configs)` wrapper accepts four par
  - _pageSizeContainerClassName_ css class for the page size component container element ('col-md-6' by default)
  - _paginationClassName_ css class for the pagination component (`null` by default)
  - _paginationContainerClassName_ css class for the pagination component container element ('col-md-12' by default)
+ - _tableContainerClassName_ css class for the table component container element ('col-md-12' by default)
+ - _sortAscIconClass_ css class for the icon indicating the column is sorted ascending ('fa fa-long-arrow-up' by default)
+ - _sortDescIconClass_ css class for the icon indicating the column is sorted descending ('fa fa-long-arrow-down' by default)
+ - _sortIconClass_ css class for the icon indicating that a column is sortable, and not currently sorted ('fa fa-arrows-v' by default)
  - _sortKey_ default column to sort by (not sorted by default)
  - _sortDirection_ default sort direction, `asc` or `desc` (`asc` by default)
 

--- a/src/Pagination.js
+++ b/src/Pagination.js
@@ -12,7 +12,6 @@ const propTypes = {
 
 class Pagination extends Component {
   render() {
-    console.log('PAGIN PROPS: ', this.props);
     const {
       page,
       pageSize,

--- a/src/Pagination.js
+++ b/src/Pagination.js
@@ -6,14 +6,17 @@ const propTypes = {
   pageCount: PropTypes.number.isRequired,
   pageSize: PropTypes.number.isRequired,
   onPageChange: PropTypes.func.isRequired,
+  className: PropTypes.string,
   autoHidePagination: PropTypes.bool,
 };
 
 class Pagination extends Component {
   render() {
+    console.log('PAGIN PROPS: ', this.props);
     const {
       page,
       pageSize,
+      className,
       onPageChange,
       autoHidePagination,
     } = this.props;
@@ -27,7 +30,7 @@ class Pagination extends Component {
     }
     if (pageCount > 1 || !autoHidePagination) {
       return (
-        <nav>
+        <nav className={className}>
           <ul className="pagination pagination-sm">
             <li className={`page-item ${hasPrevious ? '' : 'disabled'}`}>
               <a

--- a/src/SortableHeader.js
+++ b/src/SortableHeader.js
@@ -8,7 +8,7 @@ const propTypes = {
   title: PropTypes.string,
   sortAscIconClass: PropTypes.string,
   sortDescIconClass: PropTypes.string,
-  sortIconClass: PropTypes.strings,
+  sortIconClass: PropTypes.string,
 };
 
 class SortableHeader extends Component {
@@ -36,10 +36,10 @@ class SortableHeader extends Component {
         <span style={{ marginRight: '5px' }}>
           {name}
         </span>
-        {sorted === 'asc' && <i className={sortAscIconClass || 'fa fa-long-arrow-up'} />}
-        {sorted === 'desc' && <i className={sortDescIconClass || 'fa fa-long-arrow-down'} />}
+        {sorted === 'asc' && <i className={sortAscIconClass} />}
+        {sorted === 'desc' && <i className={sortDescIconClass} />}
         {sorted === null && <i
-          className={sortIconClass || 'fa fa-arrows-v'}
+          className={sortIconClass}
           style={{ color: '#ccc' }}
         />}
       </th>

--- a/src/SortableHeader.js
+++ b/src/SortableHeader.js
@@ -6,6 +6,9 @@ const propTypes = {
   handleClick: PropTypes.func.isRequired,
   sorted: PropTypes.string,
   title: PropTypes.string,
+  sortAscIconClass: PropTypes.string,
+  sortDescIconClass: PropTypes.string,
+  sortIconClass: PropTypes.strings,
 };
 
 class SortableHeader extends Component {
@@ -16,6 +19,9 @@ class SortableHeader extends Component {
       sorted,
       title,
       handleClick,
+      sortAscIconClass,
+      sortDescIconClass,
+      sortIconClass,
     } = this.props;
     return (
       <th
@@ -30,10 +36,10 @@ class SortableHeader extends Component {
         <span style={{ marginRight: '5px' }}>
           {name}
         </span>
-        {sorted === 'asc' && <i className="fa fa-long-arrow-up" />}
-        {sorted === 'desc' && <i className="fa fa-long-arrow-down" />}
+        {sorted === 'asc' && <i className={sortAscIconClass || 'fa fa-long-arrow-up'} />}
+        {sorted === 'desc' && <i className={sortDescIconClass || 'fa fa-long-arrow-down'} />}
         {sorted === null && <i
-          className="fa fa-arrows-v"
+          className={sortIconClass || 'fa fa-arrows-v'}
           style={{ color: '#ccc' }}
         />}
       </th>

--- a/src/Table.js
+++ b/src/Table.js
@@ -17,6 +17,9 @@ const propTypes = {
   styleName: PropTypes.string,
   CheckboxComponent: PropTypes.func,
   NoDataComponent: PropTypes.func,
+  sortAscIconClass: PropTypes.string,
+  sortDescIconClass: PropTypes.string,
+  sortIconClass: PropTypes.string,
 };
 
 class Table extends Component {
@@ -30,6 +33,9 @@ class Table extends Component {
       primaryKey,
       CheckboxComponent,
       NoDataComponent,
+      sortAscIconClass = 'fa fa-long-arrow-up',
+      sortDescIconClass = 'fa fa-long-arrow-down',
+      sortIconClass = 'fa fa-arrows-v',
     } = this.props;
 
     const className = this.props.className || 'table-sm table-striped table-hover';
@@ -54,6 +60,9 @@ class Table extends Component {
                   <SortableHeader
                     key={col.key}
                     title={col.title}
+                    sortAscIconClass={sortAscIconClass}
+                    sortDescIconClass={sortDescIconClass}
+                    sortIconClass={sortIconClass}
                     {...headers[col.key]}
                   />);
               }

--- a/src/TableRow.js
+++ b/src/TableRow.js
@@ -31,7 +31,7 @@ class TableRow extends Component {
       headers,
       columns,
       CheckboxComponent,
-      ...otherProps,
+      ...otherProps
     } = this.props;
     const select = headers.select;
     const visibleColumns = columns.filter((c) => !c.hidden);

--- a/src/sematable.js
+++ b/src/sematable.js
@@ -149,6 +149,7 @@ const sematable = (tableName, TableComponent, columns, configs = {}) => {
         pageSizeContainerClassName = 'col-md-6',
         filterContainerClassName = 'col-md-6',
         paginationContainerClassName = 'col-md-12',
+        tableContainerClassName = 'col-md-12',
         pageSizeClassName,
         filterClassName,
         paginationClassName,
@@ -208,7 +209,7 @@ const sematable = (tableName, TableComponent, columns, configs = {}) => {
               placeholder={filterPlaceholder}
             />}
           </div>
-          <div className="col-md-12">
+          <div className={tableContainerClassName}>
             <TableComponent
               {...otherProps}
               data={visibleRows}
@@ -219,7 +220,7 @@ const sematable = (tableName, TableComponent, columns, configs = {}) => {
               {...configs}
             />
           </div>
-          <div className="col-md-12">
+          <div className={paginationContainerClassName}>
             <Pagination
               {...pageInfo}
               className={paginationClassName}

--- a/src/sematable.js
+++ b/src/sematable.js
@@ -148,8 +148,10 @@ const sematable = (tableName, TableComponent, columns, configs = {}) => {
         autoHidePagination = true,
         pageSizeContainerClassName = 'col-md-6',
         filterContainerClassName = 'col-md-6',
+        paginationContainerClassName = 'col-md-12',
         pageSizeClassName,
         filterClassName,
+        paginationClassName,
         filterPlaceholder,
       } = configs;
 
@@ -220,6 +222,7 @@ const sematable = (tableName, TableComponent, columns, configs = {}) => {
           <div className="col-md-12">
             <Pagination
               {...pageInfo}
+              className={paginationClassName}
               autoHidePagination={autoHidePagination}
               onPageChange={(p) => onPageChange(p)}
             />


### PR DESCRIPTION
Hi There,

Found this repo via a blog post on a pursuit to make jquery DataTables Frankenstein into a React-Redux project. It really peaked my interest and I've since been tinkering with Sematable for about a day now.

This PR introduces the option for custom sorting icons, as well as extends the option to set paginationContainerClassName and paginationClassName. Seemed like a natural option given both pageSize and filter had them.

Let me know what you think.