### PR TITLE
use lodash.isEqual for data equality comparison

### DIFF
--- a/src/sematable.js
+++ b/src/sematable.js
@@ -109,7 +109,7 @@ const sematable = (tableName, TableComponent, columns, configs = {}) => {
         onNewFilterValue,
       } = this.props;
 
-      if (data !== nextProps.data) {
+      if (!(_.isEqual(data, nextProps.data))) {
         onNewData(nextProps.data);
       }
 


### PR DESCRIPTION
updated the data/nextData comparison in sematable.js's componentWillReceiveProps to use lodash.isEqual method (https://lodash.com/docs/#isEqual).

reasoning:

when using table data that wasn't held in application-wide state, and was instead created inside a redux container and subsequently passed-in via `mapStateToProps`, a table in our application was experiencing an infinite render loop.

`data !== nextProps.data` always returns true when using this method, but doesn't when checking for deep equality.

this doesn't seem to have a performance impact loading a couple hundred paginated data rows, although i'm not sure if that will remain the case at larger scales.

closes #60 

edit: currently, the only possible solution would be for me to store an entirely new state object, even though it's essentially just a join between two other object trees that *already* exist in state. this should be achievable through redux containers.