### PR TITLE
don't set default state value before TABLE_INITIALIZE action

### DIFF
--- a/src/reducer.js
+++ b/src/reducer.js
@@ -151,7 +151,7 @@ const behaviours = {
   },
 };
 
-const tableReducer = handleActions(behaviours);
+const tableReducer = handleActions(behaviours, {});
 
 export default (state, action) => {
   if (!state) {

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -151,7 +151,7 @@ const behaviours = {
   },
 };
 
-const tableReducer = handleActions(behaviours, defaultState());
+const tableReducer = handleActions(behaviours);
 
 export default (state, action) => {
   if (!state) {


### PR DESCRIPTION
if on TABLE_INITIALIZE action current state is not an empty object it will overwrite all the default values defined in config.

This is a reason why defaultPageSize in all sematables has suddenly become overwritten to 5