### PR TITLE
Pagination: limit number of page items shown

### DIFF
--- a/src/Pagination.js
+++ b/src/Pagination.js
@@ -10,6 +10,34 @@ const propTypes = {
   autoHidePagination: PropTypes.bool,
 };
 
+const pageItem = (idx, page, onPageChange) => (
+  <li key={idx} className={`page-item ${idx === page ? 'active' : ''}`}>
+    <a
+      href="#next"
+      className="page-link"
+      onClick={(e) => {
+        e.preventDefault();
+        onPageChange(idx);
+      }}
+    >
+      {idx + 1}
+    </a>
+  </li>
+);
+
+// shown pages: first, pagesBeforeCurrent, current, pagesAfterCurrent, last
+const pagesBeforeCurrent = 5;
+const pagesAfterCurrent = 5;
+const currentPageRange = (page, pageCount) => {
+  const rangeCount = Math.min(pageCount - 2, pagesBeforeCurrent + pagesAfterCurrent + 1);
+  const firstPageMinValue = 1;
+  const firstPageMaxValue = pageCount - 1 - rangeCount;
+  let firstPage = page - pagesBeforeCurrent;
+  firstPage = Math.max(firstPage, firstPageMinValue);
+  firstPage = Math.min(firstPage, firstPageMaxValue);
+  return _.range(firstPage, firstPage + rangeCount);
+};
+
 class Pagination extends Component {
   render() {
     const {
@@ -46,20 +74,11 @@ class Pagination extends Component {
                 <span className="sr-only">Previous</span>
               </a>
             </li>
-            {_.times(pageCount, (idx) => (
-              <li key={idx} className={`page-item ${idx === page ? 'active' : ''}`}>
-                <a
-                  href="#next"
-                  className="page-link"
-                  onClick={(e) => {
-                    e.preventDefault();
-                    onPageChange(idx);
-                  }}
-                >
-                  {idx + 1}
-                </a>
-              </li>
-            ))}
+            { pageItem(0, page, onPageChange) }
+            { pageCount > 2 &&
+                currentPageRange(page, pageCount).map(idx => pageItem(idx, page, onPageChange))
+            }
+            { pageCount > 1 && pageItem(pageCount - 1, page, onPageChange) }
             <li className={`page-item ${hasNext ? '' : 'disabled'}`}>
               <a
                 href="#page"


### PR DESCRIPTION
Should pagesBeforeCurrent and pagesAfterCurrent be exposed and configurable?
It seems to me that it's not likely anyone would like to configure it, so it's better to keep interface simple. 