### PR TITLE
Fix: Preserve filter when user-created-filter is added

### DIFF
--- a/src/Filter.js
+++ b/src/Filter.js
@@ -74,7 +74,8 @@ class Filter extends Component {
         options={options}
         noOptionsMessage={() => 'Type text to search, press Enter to save as filter'}
         placeholder={placeholder || defaultPlaceholder}
-        formatCreateLabel={txt => `Search for '${txt}'`}
+        formatCreateLabel={txt => `Create '${txt}' filter`}
+        isValidNewOption={input => !!input}
         onChange={selected => onChange(selected)}
         onInputChange={this.handleInputChange}
         onCreateOption={this.handleCreateOption}

--- a/src/Filter.js
+++ b/src/Filter.js
@@ -53,7 +53,7 @@ class Filter extends Component {
   handleCreateOption(val) {
     const { onChange, value } = this.props;
     const opt = createTextFilter(val);
-    onChange([...value, opt]);
+    onChange([...value, opt], 'create-option');
   }
 
   render() {
@@ -77,7 +77,7 @@ class Filter extends Component {
         formatCreateLabel={txt => `Create '${txt}' filter`}
         createOptionPosition="first"
         isValidNewOption={input => !!input}
-        onChange={selected => onChange(selected)}
+        onChange={(selected, meta) => onChange(selected, meta.action)}
         onInputChange={this.handleInputChange}
         onCreateOption={this.handleCreateOption}
         onBlur={this.handleBlur}

--- a/src/Filter.js
+++ b/src/Filter.js
@@ -51,9 +51,9 @@ class Filter extends Component {
   }
 
   handleCreateOption(val) {
-    const { onChange } = this.props;
+    const { onChange, value } = this.props;
     const opt = createTextFilter(val);
-    onChange(opt);
+    onChange([...value, opt]);
   }
 
   render() {

--- a/src/Filter.js
+++ b/src/Filter.js
@@ -75,6 +75,7 @@ class Filter extends Component {
         noOptionsMessage={() => 'Type text to search, press Enter to save as filter'}
         placeholder={placeholder || defaultPlaceholder}
         formatCreateLabel={txt => `Create '${txt}' filter`}
+        createOptionPosition="first"
         isValidNewOption={input => !!input}
         onChange={selected => onChange(selected)}
         onInputChange={this.handleInputChange}

--- a/src/FilterContainer.js
+++ b/src/FilterContainer.js
@@ -28,7 +28,7 @@ const mapStateToProps = (state, { tableName }) => {
 };
 
 const mapDispatchToProps = (dispatch, { tableName }) => ({
-  onChange: (filter) => dispatch(tableFilterChanged(tableName, filter)),
+  onChange: (filter, action) => dispatch(tableFilterChanged(tableName, filter, action)),
   onTextChange: (filterText) => dispatch(tableFilterTextChanged(tableName, filterText)),
 });
 

--- a/src/actions.js
+++ b/src/actions.js
@@ -45,11 +45,12 @@ export const tablePageSizeChanged = (tableName, pageSize) => ({
   },
 });
 
-export const tableFilterChanged = (tableName, filter) => ({
+export const tableFilterChanged = (tableName, filter, action) => ({
   type: TABLE_FILTER_CHANGED,
   payload: {
     tableName,
     filter,
+    action,
   },
 });
 

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -102,7 +102,9 @@ const behaviours = {
     ...state,
     page: 0,
     filter: payload.filter,
-    filterText: null,
+    // don't clear filterText when a single filter is removed
+    // see: https://react-select.com/advanced#action-meta
+    filterText: payload.action === 'remove-value' ? state.filterText : null,
   }),
   [TABLE_FILTER_TEXT_CHANGED]: (state, { payload }) => ({
     ...state,

--- a/src/sematable.js
+++ b/src/sematable.js
@@ -87,7 +87,7 @@ const sematable = (tableName, TableComponent, columns, configs = {}) => {
   const mapDispatchToProps = (dispatch) => ({
     onPageChange: (page) => dispatch(tablePageChanged(tableName, page)),
     onPageSizeChange: (pageSize) => dispatch(tablePageSizeChanged(tableName, pageSize)),
-    onFilterChange: (filter) => dispatch(tableFilterChanged(tableName, filter)),
+    onFilterChange: (filter, action) => dispatch(tableFilterChanged(tableName, filter, action)),
     onFilterTextChange: (filterText) => dispatch(tableFilterTextChanged(tableName, filterText)),
     onHeaderClick: (sortKey) => dispatch(tableSortChanged(tableName, sortKey)),
     onNewData: (data) => dispatch(tableNewData(tableName, data)),

--- a/src/sematable.js
+++ b/src/sematable.js
@@ -25,6 +25,7 @@ const propTypes = {
   isInitialized: PropTypes.bool.isRequired,
   visibleRows: PropTypes.array,
   filter: PropTypes.array,
+  filterText: PropTypes.string,
   sortInfo: PropTypes.object,
   pageInfo: PropTypes.object,
   selectAll: PropTypes.bool,
@@ -73,6 +74,7 @@ const sematable = (tableName, TableComponent, columns, configs = {}) => {
       isInitialized,
       visibleRows: selectors.getVisible(state, props),
       filter: selectors.getFilter(state, props),
+      filterText: selectors.getFilterText(state),
       sortInfo: selectors.getSortInfo(state, props),
       pageInfo: selectors.getPageInfo(state, props),
       selectAll: selectors.getSelectAll(state, props),
@@ -125,6 +127,7 @@ const sematable = (tableName, TableComponent, columns, configs = {}) => {
         isInitialized,
         visibleRows,
         filter,
+        filterText,
         sortInfo,
         pageInfo,
         selectAll,
@@ -223,8 +226,9 @@ const sematable = (tableName, TableComponent, columns, configs = {}) => {
             {showFilter && <Filter
               className={filterClassName}
               value={filter}
+              filterText={filterText}
               options={filterOptions}
-              onChange={(f) => onFilterChange(f)}
+              onChange={(f, a) => onFilterChange(f, a)}
               onTextChange={(f) => onFilterTextChange(f)}
               hasFilterable={hasFilterable}
               placeholder={filterPlaceholder}


### PR DESCRIPTION
Additional improvements/fixes:
 - don't remove `filterText` if individual `filter` is removed
 - show `Create filter` option on top of all options in dropdown menu (this was v1 default)
 - refactor `Filter` in `sematable.js` with latest react-select changes
 - Always show 'Create filter' option for non-empty input (by default not shown if there is option present with that value)